### PR TITLE
Added an enum for the rest of gml's color constants

### DIFF
--- a/gml/ds/Colors.hx
+++ b/gml/ds/Colors.hx
@@ -1,0 +1,26 @@
+package gml.ds;
+
+/**
+ * GameMaker's color-related constants in a convenient enum.
+ */
+@:native("c") @:std extern enum abstract Colors(Color) to Color {
+    var aqua;
+    var black;
+    var blue;
+    var dkgray;
+    var fuchsia;
+    var gray;
+    var green;
+    var lime;
+    var ltgray;
+    var maroon;
+    var navy;
+    var olive;
+    var orange;
+    var purple;
+    var red;
+    var silver;
+    var teal;
+    var white;
+    var yellow;
+}


### PR DESCRIPTION
Basic addition - found that the constants for colors were missing and this seemed like a reasonable addition. 