### PR TITLE
Makes it use the native string_pos_ext if using modern GML. Otherwise…

### DIFF
--- a/String.hx
+++ b/String.hx
@@ -26,9 +26,9 @@ class String {
 	}
 
 	#if (sfgml_modern)
-	public inline function indexOf(sub:String, startPos:Int = 0):Int {
+	public inline function indexOf(sub:String, startPos:Int = 1):Int {
 		var out = NativeString.posExt(sub, this, startPos);
-		return out > 0 ? out - 1 : -1;
+		return out - 1;
 	}
 	#else
 	@:native("pos_ext_haxe")

--- a/String.hx
+++ b/String.hx
@@ -24,12 +24,21 @@ class String {
 	public inline function charCodeAt(i:Int):Int {
 		return NativeString.charCodeAt(this, i + 1);
 	}
-	@:native("pos_ext")
+
+	#if (sfgml_modern)
+	public inline function indexOf(sub:String, startPos:Int = 0):Int {
+		var out = NativeString.posExt(sub, this, startPos);
+		return out > 0 ? out - 1 : -1;
+	}
+	#else
+	@:native("pos_ext_haxe")
 	public function indexOf(sub:String, startPos:Int = 0):Int {
 		var hay = startPos > 0 ? NativeString.delete(this, 1, startPos) : this;
 		var out = NativeString.pos(sub, hay);
 		return out > 0 ? out + startPos - 1 : -1;
 	}
+	#end
+
 	@:native("pos_last")
 	public function lastIndexOf(sub:String, ?startPos:Int):Int {
 		var i = 0, out = -1;


### PR DESCRIPTION
I was running into an issue where compiling would create its own `string_pos_ext` on GMS2.3.1. I added a check that makes it use the native version on modern GML (still returns `-1` in case it doesn't find it), and also renamed it to prevent this from happening in the future.